### PR TITLE
do not pollute Pinetime::Applications::Screens namespace

### DIFF
--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -6,7 +6,7 @@
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-  TimeSeparated_t convertTicksToTimeSegments(const TickType_t timeElapsed) {
+  StopWatch::TimeSeparated_t convertTicksToTimeSegments(const TickType_t timeElapsed) {
     // Centiseconds
     const int timeElapsedCentis = timeElapsed * 100 / configTICK_RATE_HZ;
 
@@ -14,7 +14,7 @@ namespace {
     const int secs = (timeElapsedCentis / 100) % 60;
     const int mins = ((timeElapsedCentis / 100) / 60) % 60;
     const int hours = ((timeElapsedCentis / 100) / 60) / 60;
-    return TimeSeparated_t {hours, mins, secs, hundredths};
+    return StopWatch::TimeSeparated_t {hours, mins, secs, hundredths};
   }
 
   void play_pause_event_handler(lv_obj_t* obj, lv_event_t event) {

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -16,17 +16,17 @@ namespace Pinetime {
   namespace Applications {
     namespace Screens {
 
-      enum class States { Init, Running, Halted };
-
-      struct TimeSeparated_t {
-        int hours;
-        int mins;
-        int secs;
-        int hundredths;
-      };
-
       class StopWatch : public Screen {
       public:
+        enum class States { Init, Running, Halted };
+
+        struct TimeSeparated_t {
+          int hours;
+          int mins;
+          int secs;
+          int hundredths;
+        };
+
         explicit StopWatch(System::SystemTask& systemTask);
         ~StopWatch() override;
         void Refresh() override;


### PR DESCRIPTION
with datatypes used only in/by StopWatch class