### PR TITLE
#2123: SettingWakeUp: use Checkboxlist.h

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -562,7 +562,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       currentScreen = std::make_unique<Screens::SettingWeatherFormat>(settingsController);
       break;
     case Apps::SettingWakeUp:
-      currentScreen = std::make_unique<Screens::SettingWakeUp>(settingsController);
+      currentScreen = std::make_unique<Screens::SettingWakeUp>(this, settingsController);
       break;
     case Apps::SettingDisplay:
       currentScreen = std::make_unique<Screens::SettingDisplay>(this, settingsController);

--- a/src/displayapp/screens/CheckboxList.h
+++ b/src/displayapp/screens/CheckboxList.h
@@ -27,13 +27,16 @@ namespace Pinetime {
                      const char* optionsSymbol,
                      uint32_t originalValue,
                      std::function<void(uint32_t)> OnValueChanged,
-                     std::array<Item, MaxItems> options);
+                     std::array<Item, MaxItems> options,
+                     bool radioButton = true,
+                     std::function<bool(uint32_t)> IsChecked = nullptr);
         ~CheckboxList() override;
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
         const uint8_t screenID;
         std::function<void(uint32_t)> OnValueChanged;
+        std::function<bool(uint32_t)> IsChecked_;
         std::array<Item, MaxItems> options;
         std::array<lv_obj_t*, MaxItems> cbOption;
         uint32_t value;

--- a/src/displayapp/screens/settings/SettingWakeUp.cpp
+++ b/src/displayapp/screens/settings/SettingWakeUp.cpp
@@ -1,57 +1,59 @@
 #include "displayapp/screens/settings/SettingWakeUp.h"
 #include <lvgl/lvgl.h>
-#include "displayapp/DisplayApp.h"
+
 #include "displayapp/screens/Screen.h"
 #include "displayapp/screens/Symbols.h"
-#include "components/settings/Settings.h"
+#include "displayapp/screens/CheckboxList.h"
 #include "displayapp/screens/Styles.h"
 
 using namespace Pinetime::Applications::Screens;
 
-constexpr std::array<SettingWakeUp::Option, 5> SettingWakeUp::options;
+constexpr const char* SettingWakeUp::title;
+constexpr const char* SettingWakeUp::symbol;
 
-namespace {
-  void event_handler(lv_obj_t* obj, lv_event_t event) {
-    auto* screen = static_cast<SettingWakeUp*>(obj->user_data);
-    if (event == LV_EVENT_VALUE_CHANGED) {
-      screen->UpdateSelected(obj);
+constexpr std::array<SettingWakeUp::Option, SettingWakeUp::optionsCount> SettingWakeUp::options;
+
+std::unique_ptr<Screen> SettingWakeUp::CreateScreen(unsigned int screenNum) const {
+  std::array<Screens::CheckboxList::Item, settingsPerScreen> optionsOnThisScreen;
+  for (int i = 0; i < settingsPerScreen; i++) {
+    if (i + (screenNum * settingsPerScreen) >= options.size()) {
+      optionsOnThisScreen[i] = {"", false};
+    } else {
+      auto& item = options[i + (screenNum * settingsPerScreen)];
+      optionsOnThisScreen[i] = Screens::CheckboxList::Item {item.name, true};
     }
   }
+
+  return std::make_unique<Screens::CheckboxList>(
+    screenNum,
+    nScreens,
+    title,
+    symbol,
+    optionsCount,
+    [this, &settings = settingsController](uint32_t index) {
+      bool currentState = settingsController.isWakeUpModeOn(options[index].wakeUpMode);
+      settingsController.setWakeUpMode(options[index].wakeUpMode, !currentState);
+    },
+    optionsOnThisScreen,
+    false,
+    [this, &settings = settingsController](uint32_t index) {
+      bool currentState = settingsController.isWakeUpModeOn(options[index].wakeUpMode);
+      return currentState;
+    });
 }
 
-SettingWakeUp::SettingWakeUp(Pinetime::Controllers::Settings& settingsController) : settingsController {settingsController} {
-  lv_obj_t* container1 = lv_cont_create(lv_scr_act(), nullptr);
-
-  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
-  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
-  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
-
-  lv_obj_set_pos(container1, 10, 35);
-  lv_obj_set_width(container1, LV_HOR_RES - 20);
-  lv_obj_set_height(container1, LV_VER_RES - 20);
-  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
-
-  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(title, "Wake Up");
-  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
-
-  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
-  lv_label_set_text_static(icon, Symbols::eye);
-  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
-
-  for (unsigned int i = 0; i < options.size(); i++) {
-    cbOption[i] = lv_checkbox_create(container1, nullptr);
-    lv_checkbox_set_text(cbOption[i], options[i].name);
-    if (settingsController.isWakeUpModeOn(static_cast<Controllers::Settings::WakeUpMode>(i))) {
-      lv_checkbox_set_checked(cbOption[i], true);
-    }
-    cbOption[i]->user_data = this;
-    lv_obj_set_event_cb(cbOption[i], event_handler);
+auto SettingWakeUp::CreateScreenList() const {
+  std::array<std::function<std::unique_ptr<Screen>()>, nScreens> screens;
+  for (size_t i = 0; i < screens.size(); i++) {
+    screens[i] = [this, i]() -> std::unique_ptr<Screen> {
+      return CreateScreen(i);
+    };
   }
+  return screens;
+}
+
+SettingWakeUp::SettingWakeUp(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
+  : settingsController {settingsController}, screens {app, 0, CreateScreenList(), Screens::ScreenListModes::UpDown} {
 }
 
 SettingWakeUp::~SettingWakeUp() {
@@ -59,21 +61,6 @@ SettingWakeUp::~SettingWakeUp() {
   settingsController.SaveSettings();
 }
 
-void SettingWakeUp::UpdateSelected(lv_obj_t* object) {
-  // Find the index of the checkbox that triggered the event
-  for (size_t i = 0; i < options.size(); i++) {
-    if (cbOption[i] == object) {
-      bool currentState = settingsController.isWakeUpModeOn(options[i].wakeUpMode);
-      settingsController.setWakeUpMode(options[i].wakeUpMode, !currentState);
-      break;
-    }
-  }
-
-  // Update checkbox according to current wakeup modes.
-  // This is needed because we can have extra logic when setting or unsetting wakeup modes,
-  // for example, when setting SingleTap, DoubleTap is unset and vice versa.
-  auto modes = settingsController.getWakeUpModes();
-  for (size_t i = 0; i < options.size(); ++i) {
-    lv_checkbox_set_checked(cbOption[i], modes[i]);
-  }
+bool SettingWakeUp::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
+  return screens.OnTouchEvent(event);
 }

--- a/src/displayapp/screens/settings/SettingWakeUp.h
+++ b/src/displayapp/screens/settings/SettingWakeUp.h
@@ -3,8 +3,11 @@
 #include <array>
 #include <cstdint>
 #include <lvgl/lvgl.h>
-#include "components/settings/Settings.h"
+
 #include "displayapp/screens/Screen.h"
+#include "displayapp/screens/ScreenList.h"
+#include "displayapp/screens/Symbols.h"
+#include "components/settings/Settings.h"
 
 namespace Pinetime {
 
@@ -13,19 +16,26 @@ namespace Pinetime {
 
       class SettingWakeUp : public Screen {
       public:
-        SettingWakeUp(Pinetime::Controllers::Settings& settingsController);
+        SettingWakeUp(DisplayApp* app, Pinetime::Controllers::Settings& settingsController);
         ~SettingWakeUp() override;
 
-        void UpdateSelected(lv_obj_t* object);
+        bool OnTouchEvent(TouchEvents event) override;
 
       private:
+        auto CreateScreenList() const;
+        std::unique_ptr<Screen> CreateScreen(unsigned int screenNum) const;
+
         struct Option {
           Controllers::Settings::WakeUpMode wakeUpMode;
           const char* name;
         };
 
+        static constexpr int settingsPerScreen = 4;
+        static constexpr int optionsCount = 5;
+        static constexpr int nScreens = (optionsCount - 1) / settingsPerScreen + 1;
+
         Controllers::Settings& settingsController;
-        static constexpr std::array<Option, 5> options = {{
+        static constexpr std::array<Option, optionsCount> options = {{
           {Controllers::Settings::WakeUpMode::SingleTap, "Single Tap"},
           {Controllers::Settings::WakeUpMode::DoubleTap, "Double Tap"},
           {Controllers::Settings::WakeUpMode::RaiseWrist, "Raise Wrist"},
@@ -33,7 +43,10 @@ namespace Pinetime {
           {Controllers::Settings::WakeUpMode::LowerWrist, "Lower Wrist"},
         }};
 
-        lv_obj_t* cbOption[options.size()];
+        static constexpr const char* title = "Wake Up";
+        static constexpr const char* symbol = Symbols::eye;
+
+        ScreenList<nScreens> screens;
       };
     }
   }


### PR DESCRIPTION
Update `CheckboxList.h` to optionally be able to get checkboxes (instead of the default of radio-buttons) and be able to have multi-selection through a new callback.

Use these updated capabilities of `CheckboxList.h` to replace the nearly identical code of `SettingWakeUp.h`

One noticable change is that previously all 5 wake-up-settings were on the same page. But with this PR and the default value of 4 settings per screen on `CheckboxList.h` we have two pages.

https://github.com/InfiniTimeOrg/InfiniTime/pull/2123