### PR TITLE
#2427: Fonts: make fonts part of InfiniTimeTheme

### DIFF
--- a/src/displayapp/InfiniTimeTheme.cpp
+++ b/src/displayapp/InfiniTimeTheme.cpp
@@ -218,10 +218,10 @@ static void basic_init() {
 lv_theme_t* lv_pinetime_theme_init() {
   theme.color_primary = LV_COLOR_WHITE;
   theme.color_secondary = LV_COLOR_GRAY;
-  theme.font_small = &jetbrains_mono_bold_20;
-  theme.font_normal = &jetbrains_mono_bold_20;
-  theme.font_subtitle = &jetbrains_mono_bold_20;
-  theme.font_title = &jetbrains_mono_bold_20;
+  theme.font_small = Fonts::normal;
+  theme.font_normal = Fonts::normal;
+  theme.font_subtitle = Fonts::normal;
+  theme.font_title = Fonts::normal;
   theme.flags = 0;
 
   basic_init();

--- a/src/displayapp/InfiniTimeTheme.h
+++ b/src/displayapp/InfiniTimeTheme.h
@@ -16,6 +16,14 @@ namespace Colors {
   static constexpr lv_color_t highlight = green;
 };
 
+namespace Fonts {
+  static constexpr const lv_font_t* normal = &jetbrains_mono_bold_20;
+  static constexpr const lv_font_t* mono = &jetbrains_mono_bold_20;
+  static constexpr const lv_font_t* large = &jetbrains_mono_42;
+  static constexpr const lv_font_t* huge = &jetbrains_mono_76;
+  static constexpr const lv_font_t* hugeBold = &jetbrains_mono_extrabold_compressed;
+}
+
 /**
  * Initialize the default
  * @param color_primary the primary color of the theme

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -56,7 +56,7 @@ Alarm::Alarm(Controllers::AlarmController& alarmController,
     hourCounter.EnableTwelveHourMode();
 
     lblampm = lv_label_create(lv_scr_act(), nullptr);
-    lv_obj_set_style_local_text_font(lblampm, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
+    lv_obj_set_style_local_text_font(lblampm, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::normal);
     lv_label_set_text_static(lblampm, "AM");
     lv_label_set_align(lblampm, LV_LABEL_ALIGN_CENTER);
     lv_obj_align(lblampm, lv_scr_act(), LV_ALIGN_CENTER, 0, 30);
@@ -70,7 +70,7 @@ Alarm::Alarm(Controllers::AlarmController& alarmController,
   minuteCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 
   lv_obj_t* colonLabel = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(colonLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  lv_obj_set_style_local_text_font(colonLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::huge);
   lv_label_set_text_static(colonLabel, ":");
   lv_obj_align(colonLabel, lv_scr_act(), LV_ALIGN_CENTER, 0, -29);
 

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -24,6 +24,7 @@
 #include "displayapp/Controllers.h"
 #include "systemtask/WakeLock.h"
 #include "Symbols.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -62,8 +63,8 @@ namespace Pinetime {
         void HideInfo();
         void ToggleRecurrence();
         void UpdateAlarmTime();
-        Widgets::Counter hourCounter = Widgets::Counter(0, 23, jetbrains_mono_76);
-        Widgets::Counter minuteCounter = Widgets::Counter(0, 59, jetbrains_mono_76);
+        Widgets::Counter hourCounter = Widgets::Counter(0, 23, *Fonts::huge);
+        Widgets::Counter minuteCounter = Widgets::Counter(0, 59, *Fonts::huge);
       };
     }
 

--- a/src/displayapp/screens/BatteryInfo.cpp
+++ b/src/displayapp/screens/BatteryInfo.cpp
@@ -29,7 +29,7 @@ BatteryInfo::BatteryInfo(const Pinetime::Controllers::Battery& batteryController
   lv_obj_align(status, nullptr, LV_ALIGN_IN_BOTTOM_MID, 0, -17);
 
   percent = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(percent, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(percent, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_fmt(percent, "%i%%", batteryPercent);
   lv_label_set_align(percent, LV_LABEL_ALIGN_LEFT);
   lv_obj_align(percent, chargingArc, LV_ALIGN_CENTER, 0, 0);

--- a/src/displayapp/screens/Dice.cpp
+++ b/src/displayapp/screens/Dice.cpp
@@ -4,11 +4,12 @@
 #include "components/settings/Settings.h"
 #include "components/motor/MotorController.h"
 #include "components/motion/MotionController.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-  lv_obj_t* MakeLabel(lv_font_t* font,
+  lv_obj_t* MakeLabel(const lv_font_t* font,
                       lv_color_t color,
                       lv_label_long_mode_t longMode,
                       uint8_t width,
@@ -49,7 +50,7 @@ Dice::Dice(Controllers::MotionController& motionController,
                       static_cast<uint32_t>(motionController.Z())};
   gen.seed(sseq);
 
-  lv_obj_t* nCounterLabel = MakeLabel(&jetbrains_mono_bold_20,
+  lv_obj_t* nCounterLabel = MakeLabel(Fonts::normal,
                                       LV_COLOR_WHITE,
                                       LV_LABEL_LONG_EXPAND,
                                       0,
@@ -60,7 +61,7 @@ Dice::Dice(Controllers::MotionController& motionController,
                                       0,
                                       0);
 
-  lv_obj_t* dCounterLabel = MakeLabel(&jetbrains_mono_bold_20,
+  lv_obj_t* dCounterLabel = MakeLabel(Fonts::normal,
                                       LV_COLOR_WHITE,
                                       LV_LABEL_LONG_EXPAND,
                                       0,
@@ -82,7 +83,7 @@ Dice::Dice(Controllers::MotionController& motionController,
   std::uniform_int_distribution<> distrib(0, resultColors.size() - 1);
   currentColorIndex = distrib(gen);
 
-  resultTotalLabel = MakeLabel(&jetbrains_mono_42,
+  resultTotalLabel = MakeLabel(Fonts::large,
                                resultColors[currentColorIndex],
                                LV_LABEL_LONG_BREAK,
                                120,
@@ -92,7 +93,7 @@ Dice::Dice(Controllers::MotionController& motionController,
                                LV_ALIGN_IN_TOP_RIGHT,
                                11,
                                38);
-  resultIndividualLabel = MakeLabel(&jetbrains_mono_bold_20,
+  resultIndividualLabel = MakeLabel(Fonts::normal,
                                     resultColors[currentColorIndex],
                                     LV_LABEL_LONG_BREAK,
                                     90,
@@ -112,16 +113,8 @@ Dice::Dice(Controllers::MotionController& motionController,
   lv_obj_set_size(btnRoll, 240, 50);
   lv_obj_align(btnRoll, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
 
-  btnRollLabel = MakeLabel(&jetbrains_mono_bold_20,
-                           LV_COLOR_WHITE,
-                           LV_LABEL_LONG_EXPAND,
-                           0,
-                           LV_LABEL_ALIGN_CENTER,
-                           Symbols::dice,
-                           btnRoll,
-                           LV_ALIGN_CENTER,
-                           0,
-                           0);
+  btnRollLabel =
+    MakeLabel(Fonts::normal, LV_COLOR_WHITE, LV_LABEL_LONG_EXPAND, 0, LV_LABEL_ALIGN_CENTER, Symbols::dice, btnRoll, LV_ALIGN_CENTER, 0, 0);
 
   // Spagetti code in motion controller: it only updates the shake speed when shake to wake is on...
   enableShakeForDice = !settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake);

--- a/src/displayapp/screens/Dice.h
+++ b/src/displayapp/screens/Dice.h
@@ -5,6 +5,7 @@
 #include "displayapp/widgets/Counter.h"
 #include "displayapp/Controllers.h"
 #include "Symbols.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 #include <array>
 #include <random>
@@ -35,8 +36,8 @@ namespace Pinetime {
         uint8_t currentColorIndex;
         void NextColor();
 
-        Widgets::Counter nCounter = Widgets::Counter(1, 9, jetbrains_mono_42);
-        Widgets::Counter dCounter = Widgets::Counter(2, 99, jetbrains_mono_42);
+        Widgets::Counter nCounter = Widgets::Counter(1, 9, *Fonts::large);
+        Widgets::Counter dCounter = Widgets::Counter(2, 99, *Fonts::large);
 
         bool openingRoll = true;
         uint8_t currentRollHysteresis = 0;

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -33,7 +33,7 @@ HeartRate::HeartRate(Controllers::HeartRateController& heartRateController, Syst
   bool isHrRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
   label_hr = lv_label_create(lv_scr_act(), nullptr);
 
-  lv_obj_set_style_local_text_font(label_hr, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  lv_obj_set_style_local_text_font(label_hr, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::huge);
 
   if (isHrRunning) {
     lv_obj_set_style_local_text_color(label_hr, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::highlight);

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -10,7 +10,7 @@ namespace {
     screen->OnEvent(obj, event);
   }
 
-  lv_obj_t* createLabel(const char* name, lv_obj_t* reference, lv_align_t align, lv_font_t* font, uint8_t x, uint8_t y) {
+  lv_obj_t* createLabel(const char* name, lv_obj_t* reference, lv_align_t align, const lv_font_t* font, uint8_t x, uint8_t y) {
     lv_obj_t* label = lv_label_create(lv_scr_act(), nullptr);
     lv_obj_set_style_local_text_font(label, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, font);
     lv_obj_set_style_local_text_color(label, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::lightGray);
@@ -35,8 +35,8 @@ Metronome::Metronome(Controllers::MotorController& motorController, System::Syst
   lv_arc_set_adjustable(bpmArc, true);
   lv_obj_align(bpmArc, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
 
-  bpmValue = createLabel("120", bpmArc, LV_ALIGN_IN_TOP_MID, &jetbrains_mono_76, 0, 55);
-  createLabel("bpm", bpmValue, LV_ALIGN_OUT_BOTTOM_MID, &jetbrains_mono_bold_20, 0, 0);
+  bpmValue = createLabel("120", bpmArc, LV_ALIGN_IN_TOP_MID, Fonts::huge, 0, 55);
+  createLabel("bpm", bpmValue, LV_ALIGN_OUT_BOTTOM_MID, Fonts::normal, 0, 0);
 
   bpmTap = lv_btn_create(lv_scr_act(), nullptr);
   bpmTap->user_data = this;

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -213,7 +213,7 @@ Navigation::Navigation(Pinetime::Controllers::NavigationService& nav) : navServi
   txtManDist = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtManDist, LV_LABEL_LONG_BREAK);
   lv_obj_set_style_local_text_color(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
-  lv_obj_set_style_local_text_font(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_obj_set_width(txtManDist, LV_HOR_RES);
   lv_label_set_text_static(txtManDist, "--M");
   lv_label_set_align(txtManDist, LV_LABEL_ALIGN_CENTER);

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -7,8 +7,6 @@
 #include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
-extern lv_font_t jetbrains_mono_extrabold_compressed;
-extern lv_font_t jetbrains_mono_bold_20;
 
 Notifications::Notifications(DisplayApp* app,
                              Pinetime::Controllers::NotificationManager& notificationManager,

--- a/src/displayapp/screens/Paddle.cpp
+++ b/src/displayapp/screens/Paddle.cpp
@@ -1,6 +1,7 @@
 #include "displayapp/screens/Paddle.h"
 #include "displayapp/DisplayApp.h"
 #include "displayapp/LittleVgl.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 #include <cstdlib> // for rand()
 
@@ -16,7 +17,7 @@ Paddle::Paddle(Pinetime::Components::LittleVgl& lvgl) : lvgl {lvgl} {
   lv_obj_set_style_local_border_width(background, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 1);
 
   points = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(points, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(points, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_static(points, "0000");
   lv_obj_align(points, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 10);
 

--- a/src/displayapp/screens/PassKey.cpp
+++ b/src/displayapp/screens/PassKey.cpp
@@ -1,12 +1,13 @@
 #include "PassKey.h"
 #include "displayapp/DisplayApp.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
 
 PassKey::PassKey(uint32_t key) {
   passkeyLabel = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(passkeyLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
-  lv_obj_set_style_local_text_font(passkeyLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(passkeyLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_fmt(passkeyLabel, "%06u", key);
   lv_obj_align(passkeyLabel, nullptr, LV_ALIGN_CENTER, 0, -20);
 }

--- a/src/displayapp/screens/Steps.cpp
+++ b/src/displayapp/screens/Steps.cpp
@@ -38,7 +38,7 @@ Steps::Steps(Controllers::MotionController& motionController, Controllers::Setti
 
   lSteps = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lSteps, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_LIME);
-  lv_obj_set_style_local_text_font(lSteps, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(lSteps, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_fmt(lSteps, "%lu", stepsCount);
   lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -40);
 
@@ -49,12 +49,14 @@ Steps::Steps(Controllers::MotionController& motionController, Controllers::Setti
 
   lStepsYesterday = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lStepsYesterday, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::lightGray);
+  lv_obj_set_style_local_text_font(lStepsYesterday, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_text_fmt(lStepsYesterday, yesterdayStr, motionController.NbSteps(Days::Yesterday));
   lv_label_set_align(lStepsYesterday, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(lStepsYesterday, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
 
   lv_obj_t* lstepsGoal = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lstepsGoal, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
+  lv_obj_set_style_local_text_font(lstepsGoal, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_text_fmt(lstepsGoal, "Goal: %5lu", settingsController.GetStepsGoal());
   lv_label_set_align(lstepsGoal, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(lstepsGoal, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 40);
@@ -73,6 +75,7 @@ Steps::Steps(Controllers::MotionController& motionController, Controllers::Setti
 
   tripLabel = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(tripLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
+  lv_obj_set_style_local_text_font(tripLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_text_fmt(tripLabel, "Trip: %5li", currentTripSteps);
   lv_obj_align(tripLabel, lstepsGoal, LV_ALIGN_IN_LEFT_MID, 0, 20);
 

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -65,7 +65,7 @@ StopWatch::StopWatch(System::SystemTask& systemTask, StopWatchController& stopWa
 
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::huge);
   lv_label_set_text_static(time, "00:00");
   lv_label_set_long_mode(time, LV_LABEL_LONG_CROP);
   lv_label_set_align(time, LV_LABEL_ALIGN_CENTER);
@@ -201,7 +201,7 @@ void StopWatch::RenderLaps() {
 
 void StopWatch::SetHoursVisible(bool visible) {
   if (hoursVisible != visible) {
-    lv_font_t* font = visible ? &jetbrains_mono_42 : &jetbrains_mono_76;
+    const lv_font_t* font = visible ? Fonts::large : Fonts::huge;
     lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, font);
     lv_obj_set_height(time, font->line_height);
     lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, visible ? 5 : 0);

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -21,7 +21,7 @@ Timer::Timer(Controllers::Timer& timerController, Controllers::MotorController& 
   : timer {timerController}, motorController {motorController}, wakeLock(systemTask) {
 
   lv_obj_t* colonLabel = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(colonLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  lv_obj_set_style_local_text_font(colonLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::huge);
   lv_obj_set_style_local_text_color(colonLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_label_set_text_static(colonLabel, ":");
   lv_obj_align(colonLabel, lv_scr_act(), LV_ALIGN_CENTER, 0, -29);

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -11,6 +11,7 @@
 
 #include "components/timer/Timer.h"
 #include "Symbols.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 namespace Pinetime::Applications {
   namespace Screens {
@@ -44,8 +45,8 @@ namespace Pinetime::Applications {
       lv_objmask_mask_t* highlightMask;
 
       lv_task_t* taskRefresh;
-      Widgets::Counter minuteCounter = Widgets::Counter(0, 59, jetbrains_mono_76);
-      Widgets::Counter secondCounter = Widgets::Counter(0, 59, jetbrains_mono_76);
+      Widgets::Counter minuteCounter = Widgets::Counter(0, 59, *Fonts::huge);
+      Widgets::Counter secondCounter = Widgets::Counter(0, 59, *Fonts::huge);
 
       bool buttonPressing = false;
       lv_coord_t maskPosition = 0;

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -13,6 +13,7 @@
 #include "components/motion/MotionController.h"
 #include "components/ble/SimpleWeatherService.h"
 #include "components/settings/Settings.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
 
@@ -58,7 +59,7 @@ WatchFaceDigital::WatchFaceDigital(Controllers::DateTime& dateTimeController,
   lv_obj_set_style_local_text_color(label_date, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x999999));
 
   label_time = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(label_time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
+  lv_obj_set_style_local_text_font(label_time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::hugeBold);
 
   lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
 

--- a/src/displayapp/screens/WatchFacePrideFlag.cpp
+++ b/src/displayapp/screens/WatchFacePrideFlag.cpp
@@ -3,6 +3,7 @@
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "displayapp/screens/Symbols.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
 
@@ -147,7 +148,7 @@ WatchFacePrideFlag::WatchFacePrideFlag(Controllers::DateTime& dateTimeController
   lv_label_set_recolor(labelTime, true);
   lv_obj_align(labelTime, lv_scr_act(), LV_ALIGN_CENTER, 0, -1);
   lv_label_set_align(labelTime, LV_LABEL_ALIGN_CENTER);
-  lv_obj_set_style_local_text_font(labelTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(labelTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_obj_set_auto_realign(labelTime, true);
 
   labelDay = lv_label_create(lv_scr_act(), nullptr);

--- a/src/displayapp/screens/WatchFaceTerminal.cpp
+++ b/src/displayapp/screens/WatchFaceTerminal.cpp
@@ -41,32 +41,41 @@ WatchFaceTerminal::WatchFaceTerminal(Controllers::DateTime& dateTimeController,
 
   labelPrompt1 = lv_label_create(container, nullptr);
   lv_obj_set_style_local_text_color(labelPrompt1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::lightGray);
+  lv_obj_set_style_local_text_font(labelPrompt1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_text_static(labelPrompt1, "user@watch:~ $ now");
 
   labelTime = lv_label_create(container, nullptr);
+  lv_obj_set_style_local_text_font(labelTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_recolor(labelTime, true);
 
   labelDate = lv_label_create(container, nullptr);
+  lv_obj_set_style_local_text_font(labelDate, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_recolor(labelDate, true);
 
   batteryValue = lv_label_create(container, nullptr);
+  lv_obj_set_style_local_text_font(batteryValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_recolor(batteryValue, true);
 
   stepValue = lv_label_create(container, nullptr);
   lv_label_set_recolor(stepValue, true);
   lv_obj_set_style_local_text_color(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::orange);
+  lv_obj_set_style_local_text_font(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
 
   heartbeatValue = lv_label_create(container, nullptr);
+  lv_obj_set_style_local_text_font(heartbeatValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_recolor(heartbeatValue, true);
 
   weather = lv_label_create(container, nullptr);
+  lv_obj_set_style_local_text_font(weather, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_recolor(weather, true);
 
   connectState = lv_label_create(container, nullptr);
+  lv_obj_set_style_local_text_font(connectState, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_recolor(connectState, true);
 
   labelPrompt2 = lv_label_create(container, nullptr);
   lv_obj_set_style_local_text_color(labelPrompt2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::lightGray);
+  lv_obj_set_style_local_text_font(labelPrompt2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::mono);
   lv_label_set_text_static(labelPrompt2, "user@watch:~ $");
 
   lv_obj_align(container, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 7);

--- a/src/displayapp/screens/Weather.cpp
+++ b/src/displayapp/screens/Weather.cpp
@@ -29,7 +29,7 @@ Weather::Weather(Controllers::Settings& settingsController, Controllers::SimpleW
 
   temperature = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-  lv_obj_set_style_local_text_font(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text(temperature, "---");
   lv_obj_align(temperature, nullptr, LV_ALIGN_CENTER, 0, -30);
   lv_obj_set_auto_realign(temperature, true);

--- a/src/displayapp/screens/settings/SettingSetDate.h
+++ b/src/displayapp/screens/settings/SettingSetDate.h
@@ -7,6 +7,7 @@
 #include "displayapp/widgets/Counter.h"
 #include "displayapp/widgets/DotIndicator.h"
 #include "displayapp/screens/settings/SettingSetDateTime.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -27,9 +28,9 @@ namespace Pinetime {
         lv_obj_t* btnSetTime;
         lv_obj_t* lblSetTime;
 
-        Widgets::Counter dayCounter = Widgets::Counter(1, 31, jetbrains_mono_bold_20);
-        Widgets::Counter monthCounter = Widgets::Counter(1, 12, jetbrains_mono_bold_20);
-        Widgets::Counter yearCounter = Widgets::Counter(1970, 9999, jetbrains_mono_bold_20);
+        Widgets::Counter dayCounter = Widgets::Counter(1, 31, *Fonts::normal);
+        Widgets::Counter monthCounter = Widgets::Counter(1, 12, *Fonts::normal);
+        Widgets::Counter yearCounter = Widgets::Counter(1970, 9999, *Fonts::normal);
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -41,7 +41,7 @@ SettingSetTime::SettingSetTime(Pinetime::Controllers::DateTime& dateTimeControll
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
   lv_obj_t* staticLabel = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(staticLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(staticLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_static(staticLabel, "00:00:00");
   lv_obj_align(staticLabel, lv_scr_act(), LV_ALIGN_CENTER, 0, POS_Y_TEXT);
 
@@ -59,7 +59,7 @@ SettingSetTime::SettingSetTime(Pinetime::Controllers::DateTime& dateTimeControll
   minuteCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 
   lblampm = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(lblampm, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
+  lv_obj_set_style_local_text_font(lblampm, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::normal);
   lv_label_set_text_static(lblampm, "  ");
   lv_obj_align(lblampm, lv_scr_act(), LV_ALIGN_CENTER, 75, -50);
 

--- a/src/displayapp/screens/settings/SettingSetTime.h
+++ b/src/displayapp/screens/settings/SettingSetTime.h
@@ -8,6 +8,7 @@
 #include "displayapp/screens/Screen.h"
 #include "displayapp/widgets/DotIndicator.h"
 #include "displayapp/screens/settings/SettingSetDateTime.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -30,8 +31,8 @@ namespace Pinetime {
         lv_obj_t* lblampm;
         lv_obj_t* btnSetTime;
         lv_obj_t* lblSetTime;
-        Widgets::Counter hourCounter = Widgets::Counter(0, 23, jetbrains_mono_42);
-        Widgets::Counter minuteCounter = Widgets::Counter(0, 59, jetbrains_mono_42);
+        Widgets::Counter hourCounter = Widgets::Counter(0, 23, *Fonts::large);
+        Widgets::Counter minuteCounter = Widgets::Counter(0, 59, *Fonts::large);
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingSteps.cpp
+++ b/src/displayapp/screens/settings/SettingSteps.cpp
@@ -39,7 +39,7 @@ SettingSteps::SettingSteps(Pinetime::Controllers::Settings& settingsController) 
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
   stepValue = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_fmt(stepValue, "%lu", settingsController.GetStepsGoal());
   lv_label_set_align(stepValue, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_CENTER, 0, -20);
@@ -53,7 +53,7 @@ SettingSteps::SettingSteps(Pinetime::Controllers::Settings& settingsController) 
   lv_obj_align(btnPlus, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
   lv_obj_set_style_local_bg_color(btnPlus, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
   lv_obj_t* lblPlus = lv_label_create(btnPlus, nullptr);
-  lv_obj_set_style_local_text_font(lblPlus, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(lblPlus, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_static(lblPlus, "+");
   lv_obj_set_event_cb(btnPlus, event_handler);
 
@@ -64,7 +64,7 @@ SettingSteps::SettingSteps(Pinetime::Controllers::Settings& settingsController) 
   lv_obj_align(btnMinus, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_obj_set_style_local_bg_color(btnMinus, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
   lv_obj_t* lblMinus = lv_label_create(btnMinus, nullptr);
-  lv_obj_set_style_local_text_font(lblMinus, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(lblMinus, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_static(lblMinus, "-");
 }
 

--- a/src/displayapp/widgets/Counter.cpp
+++ b/src/displayapp/widgets/Counter.cpp
@@ -29,7 +29,8 @@ namespace {
   }
 }
 
-Counter::Counter(int min, int max, lv_font_t& font) : min {min}, max {max}, value {min}, leadingZeroCount {digitCount(max)}, font {font} {
+Counter::Counter(int min, int max, const lv_font_t& font)
+  : min {min}, max {max}, value {min}, leadingZeroCount {digitCount(max)}, font {font} {
 }
 
 void Counter::UpBtnPressed() {
@@ -151,7 +152,7 @@ void Counter::Create() {
   lv_obj_set_event_cb(upBtn, upBtnEventHandler);
 
   lv_obj_t* upLabel = lv_label_create(upBtn, nullptr);
-  lv_obj_set_style_local_text_font(upLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(upLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_static(upLabel, "+");
   lv_obj_align(upLabel, nullptr, LV_ALIGN_CENTER, 0, 0);
 
@@ -163,7 +164,7 @@ void Counter::Create() {
   lv_obj_set_event_cb(downBtn, downBtnEventHandler);
 
   lv_obj_t* downLabel = lv_label_create(downBtn, nullptr);
-  lv_obj_set_style_local_text_font(downLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_font(downLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Fonts::large);
   lv_label_set_text_static(downLabel, "-");
   lv_obj_align(downLabel, nullptr, LV_ALIGN_CENTER, 0, 0);
 

--- a/src/displayapp/widgets/Counter.h
+++ b/src/displayapp/widgets/Counter.h
@@ -6,7 +6,7 @@ namespace Pinetime {
     namespace Widgets {
       class Counter {
       public:
-        Counter(int min, int max, lv_font_t& font);
+        Counter(int min, int max, const lv_font_t& font);
 
         void Create();
         void UpBtnPressed();
@@ -44,7 +44,7 @@ namespace Pinetime {
         const int leadingZeroCount;
         bool twelveHourMode = false;
         bool monthMode = false;
-        lv_font_t& font;
+        const lv_font_t& font;
 
         void* userData = nullptr;
       };


### PR DESCRIPTION
Added a Fonts namespace to the InfiniTimeTheme, which provides references to the available standard fonts. Instead of directly referencing fonts in various code places, we can now rely on the Theme's settings. This makes it easier to try out different fonts and have the setting applied system-wide.

https://github.com/InfiniTimeOrg/InfiniTime/pull/2427